### PR TITLE
pinned cattrs library to version 1.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 snowflake-connector-python==2.3.2
 toolz==0.10.0
+cattrs==1.0.0


### PR DESCRIPTION
The latest version of the cattrs python library (v1.1.1, released two weeks ago) breaks airflow's CLI code. 

Pinning cattrs to v1.0.0 fixes this